### PR TITLE
Mobile-responsive layout, image attachments, session list

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
           <span id="status-text" class="status-text">Connecting…</span>
         </div>
         <div class="header-right">
+          <button id="btn-history" class="btn btn-ghost" title="Previous chats">⌛ History</button>
           <button id="btn-new" class="btn btn-ghost" title="New session">＋ New</button>
         </div>
       </header>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,17 @@
         <span class="spinner"></span> Working…
       </div>
 
+      <div id="attachment-strip" class="attachment-strip hidden"></div>
+
       <div id="input-bar" class="input-bar">
+        <input
+          type="file"
+          id="file-input"
+          class="hidden"
+          accept="image/png,image/jpeg,image/gif,image/webp"
+          multiple
+        />
+        <button id="btn-attach" class="btn btn-ghost btn-attach" title="Attach image" aria-label="Attach image">📎</button>
         <textarea
           id="prompt-input"
           class="prompt-input"

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,7 @@ import {
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
 import type { AgentSession } from "@mariozechner/pi-coding-agent";
+import type { ImageContent } from "@mariozechner/pi-ai";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PUBLIC_DIR = path.resolve(__dirname, "../dist");
@@ -110,6 +111,29 @@ function broadcast(wss: WebSocketServer, msg: unknown) {
       client.send(data);
     }
   }
+}
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB decoded
+const ALLOWED_IMAGE_MIME = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+function normaliseImages(raw: unknown): ImageContent[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ImageContent[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as { data?: unknown; mimeType?: unknown };
+    if (typeof e.data !== "string" || typeof e.mimeType !== "string") continue;
+    if (!ALLOWED_IMAGE_MIME.has(e.mimeType)) continue;
+    // Approximate decoded size; base64 inflates by ~4/3.
+    if ((e.data.length * 3) / 4 > MAX_IMAGE_BYTES) continue;
+    out.push({ type: "image", data: e.data, mimeType: e.mimeType });
+  }
+  return out;
 }
 
 function createExtensionUIContext(wss: WebSocketServer) {
@@ -318,17 +342,20 @@ async function main() {
       try {
         switch (cmd.type) {
           case "prompt": {
-            const text = cmd.message as string;
-            if (!text) break;
+            const text = (cmd.message as string) ?? "";
+            const images = normaliseImages(cmd.images);
+            if (!text && images.length === 0) break;
+            const imageOpt = images.length > 0 ? { images } : {};
             if (session.isStreaming) {
               await session.prompt(text, {
+                ...imageOpt,
                 streamingBehavior:
                   (cmd.streamingBehavior as "steer" | "followUp") ?? "followUp",
               });
             } else {
               // Don't await — prompt is async and we don't want to block the ws handler.
               // Events stream via the subscription above.
-              session.prompt(text).catch((err) => {
+              session.prompt(text, imageOpt).catch((err) => {
                 console.error("[prompt error]", err);
               });
             }

--- a/server/index.ts
+++ b/server/index.ts
@@ -121,6 +121,78 @@ const ALLOWED_IMAGE_MIME = new Set([
   "image/webp",
 ]);
 
+interface SessionListEntry {
+  file: string;
+  id: string;
+  timestamp: string;
+  preview: string;
+  isActive: boolean;
+}
+
+async function listSessions(session: AgentSession): Promise<SessionListEntry[]> {
+  const dir = session.sessionManager.getSessionDir();
+  const currentFile = session.sessionManager.getSessionFile();
+  let names: string[];
+  try {
+    names = await fs.promises.readdir(dir);
+  } catch {
+    return [];
+  }
+  const entries: SessionListEntry[] = [];
+  for (const name of names) {
+    if (!name.endsWith(".jsonl")) continue;
+    const full = path.join(dir, name);
+    try {
+      const stat = await fs.promises.stat(full);
+      if (!stat.isFile()) continue;
+      const content = await fs.promises.readFile(full, "utf8");
+      const lines = content.split("\n");
+      let header: { id?: string; timestamp?: string; type?: string } = {};
+      try {
+        header = JSON.parse(lines[0] ?? "");
+      } catch {
+        // Not a valid session file
+        continue;
+      }
+      if (header.type !== "session") continue;
+      let preview = "";
+      // Scan up to ~200 lines for the first user message
+      for (let i = 1; i < Math.min(lines.length, 200); i++) {
+        const line = lines[i];
+        if (!line || !line.trim()) continue;
+        try {
+          const entry = JSON.parse(line);
+          if (entry?.type !== "message") continue;
+          if (entry?.message?.role !== "user") continue;
+          const c = entry.message.content;
+          if (typeof c === "string") {
+            preview = c;
+          } else if (Array.isArray(c)) {
+            const t = c.find((x: { type?: string }) => x?.type === "text") as
+              | { text?: string }
+              | undefined;
+            if (t?.text) preview = t.text;
+          }
+          if (preview) break;
+        } catch {
+          // Skip malformed lines
+        }
+      }
+      entries.push({
+        file: full,
+        id: header.id ?? name,
+        timestamp: header.timestamp ?? stat.mtime.toISOString(),
+        preview: preview.replace(/\s+/g, " ").trim().slice(0, 120),
+        isActive: full === currentFile,
+      });
+    } catch (err) {
+      console.error(`[listSessions: ${name}]`, err);
+    }
+  }
+  entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return entries;
+}
+
 function normaliseImages(raw: unknown): ImageContent[] {
   if (!Array.isArray(raw)) return [];
   const out: ImageContent[] = [];
@@ -377,6 +449,42 @@ async function main() {
               sessionId: session.sessionId,
             });
             break;
+
+          case "list_sessions": {
+            const entries = await listSessions(session);
+            ws.send(JSON.stringify({ type: "sessions_list", entries }));
+            break;
+          }
+
+          case "switch_session": {
+            const file = cmd.file;
+            if (typeof file !== "string" || !file) break;
+            const dir = session.sessionManager.getSessionDir();
+            const resolved = path.resolve(file);
+            const dirResolved = path.resolve(dir);
+            // Path-traversal guard: file must live inside the sessions dir
+            if (!resolved.startsWith(dirResolved + path.sep)) {
+              console.error("[switch_session] rejected path outside sessions dir:", file);
+              break;
+            }
+            try {
+              const ok = await session.switchSession(resolved);
+              if (!ok) {
+                console.error("[switch_session] cancelled by extension");
+                break;
+              }
+              broadcast(wss, {
+                type: "state_sync",
+                messages: session.messages,
+                streaming: session.isStreaming,
+                model: session.model?.id,
+                sessionId: session.sessionId,
+              });
+            } catch (err) {
+              console.error("[switch_session]", err);
+            }
+            break;
+          }
 
           case "extension_ui_response": {
             const id = cmd.id as string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,9 +39,14 @@ interface ToolBlock {
 }
 type Block = ThinkingBlock | TextBlock | ToolBlock;
 
+interface AttachedImage {
+  data: string; // base64 (no data: prefix)
+  mimeType: string;
+}
 interface UserItem {
   kind: "user";
   text: string;
+  images?: AttachedImage[];
 }
 interface AssistantItem {
   kind: "assistant";
@@ -69,7 +74,16 @@ const state = {
   streaming: false,
   items: [] as ConversationItem[],
   dialog: null as ExtUIRequest | null,
+  pendingImages: [] as AttachedImage[],
 };
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_IMAGE_MIME = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
 
 let currentAssistantItem: AssistantItem | null = null;
 let ws: WebSocket | null = null;
@@ -83,6 +97,9 @@ const $input     = document.getElementById("prompt-input") as HTMLTextAreaElemen
 const $btnSend   = document.getElementById("btn-send")!;
 const $btnAbort  = document.getElementById("btn-abort")!;
 const $btnNew    = document.getElementById("btn-new")!;
+const $btnAttach = document.getElementById("btn-attach")!;
+const $fileInput = document.getElementById("file-input") as HTMLInputElement;
+const $attachStrip = document.getElementById("attachment-strip")!;
 const $overlay   = document.getElementById("dialog-overlay")!;
 const $dialogBox = document.getElementById("dialog-box")!;
 
@@ -141,17 +158,26 @@ function handleStateSync(data: Record<string, unknown>) {
       if (msg.role === "user") {
         const content = msg.content;
         let text: string;
+        const images: AttachedImage[] = [];
         if (typeof content === "string") {
           text = content;
         } else if (Array.isArray(content)) {
-          text = (content as Array<Record<string, unknown>>)
+          const arr = content as Array<Record<string, unknown>>;
+          text = arr
             .filter((c) => c.type === "text")
             .map((c) => c.text as string)
             .join("\n");
+          for (const c of arr) {
+            if (c.type === "image" && typeof c.data === "string" && typeof c.mimeType === "string") {
+              images.push({ data: c.data, mimeType: c.mimeType });
+            }
+          }
         } else {
           text = String(content);
         }
-        state.items.push({ kind: "user", text });
+        const item: UserItem = { kind: "user", text };
+        if (images.length > 0) item.images = images;
+        state.items.push(item);
       } else if (msg.role === "assistant") {
         const contentArr = msg.content as Array<Record<string, unknown>> | undefined;
         const blocks: Block[] = [];
@@ -343,7 +369,24 @@ function renderUserMsg(item: UserItem): HTMLElement {
   div.className = "msg msg-user";
   const bubble = document.createElement("div");
   bubble.className = "msg-bubble";
-  bubble.textContent = item.text;
+  if (item.images && item.images.length > 0) {
+    const imgs = document.createElement("div");
+    imgs.className = "msg-bubble-images";
+    for (const img of item.images) {
+      const el = document.createElement("img");
+      el.src = `data:${img.mimeType};base64,${img.data}`;
+      el.alt = "attachment";
+      imgs.appendChild(el);
+    }
+    bubble.appendChild(imgs);
+  }
+  if (item.text) {
+    const txt = document.createElement("div");
+    txt.textContent = item.text;
+    bubble.appendChild(txt);
+  } else if (!item.images || item.images.length === 0) {
+    bubble.textContent = item.text;
+  }
   div.appendChild(bubble);
   return div;
 }
@@ -575,13 +618,21 @@ function getArgPreview(name: string, args: unknown): string {
 // ── Input handling ────────────────────────────────────────────────────────────
 function sendPrompt() {
   const text = $input.value.trim();
-  if (!text || !state.connected || state.streaming) return;
+  const images = state.pendingImages;
+  if (!state.connected || state.streaming) return;
+  if (!text && images.length === 0) return;
 
-  state.items.push({ kind: "user", text });
+  const item: UserItem = { kind: "user", text };
+  if (images.length > 0) item.images = images.slice();
+  state.items.push(item);
   $input.value = "";
+  state.pendingImages = [];
   autoResizeInput();
+  renderAttachmentStrip();
   renderMessages();
-  send({ type: "prompt", message: text });
+  const payload: Record<string, unknown> = { type: "prompt", message: text };
+  if (images.length > 0) payload.images = images;
+  send(payload);
 }
 
 $btnSend.addEventListener("click", sendPrompt);
@@ -591,6 +642,72 @@ $btnNew.addEventListener("click", () => {
   // The server will broadcast a state_sync event to every connected client.
   send({ type: "new_session" });
 });
+
+// ── Attachments ───────────────────────────────────────────────────────────────
+$btnAttach.addEventListener("click", () => $fileInput.click());
+$fileInput.addEventListener("change", async () => {
+  const files = Array.from($fileInput.files ?? []);
+  $fileInput.value = ""; // reset so re-picking the same file fires change
+  for (const file of files) {
+    if (!ALLOWED_IMAGE_MIME.has(file.type)) {
+      showToast(`Unsupported file type: ${file.type || "unknown"}`, "warning");
+      continue;
+    }
+    if (file.size > MAX_IMAGE_BYTES) {
+      showToast(`Image too large: ${file.name} (${Math.round(file.size / 1024 / 1024)}MB, max 10MB)`, "warning");
+      continue;
+    }
+    try {
+      const data = await fileToBase64(file);
+      state.pendingImages.push({ data, mimeType: file.type });
+    } catch (err) {
+      showToast(`Failed to read ${file.name}`, "error");
+      console.error("[attach error]", err);
+    }
+  }
+  renderAttachmentStrip();
+});
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      const comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+function renderAttachmentStrip() {
+  $attachStrip.innerHTML = "";
+  if (state.pendingImages.length === 0) {
+    $attachStrip.classList.add("hidden");
+    return;
+  }
+  $attachStrip.classList.remove("hidden");
+  state.pendingImages.forEach((img, idx) => {
+    const chip = document.createElement("div");
+    chip.className = "attachment-chip";
+    const el = document.createElement("img");
+    el.src = `data:${img.mimeType};base64,${img.data}`;
+    el.alt = "attachment preview";
+    chip.appendChild(el);
+    const rm = document.createElement("button");
+    rm.className = "remove";
+    rm.type = "button";
+    rm.textContent = "×";
+    rm.title = "Remove";
+    rm.addEventListener("click", () => {
+      state.pendingImages.splice(idx, 1);
+      renderAttachmentStrip();
+    });
+    chip.appendChild(rm);
+    $attachStrip.appendChild(chip);
+  });
+}
 
 $input.addEventListener("keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,14 @@ interface AssistantItem {
 }
 type ConversationItem = UserItem | AssistantItem;
 
+interface SessionListEntry {
+  file: string;
+  id: string;
+  timestamp: string;
+  preview: string;
+  isActive: boolean;
+}
+
 interface ExtUIRequest {
   id: string;
   method: "select" | "confirm" | "input" | "editor" | "notify" | "setStatus" | "setWidget" | "setTitle" | "set_editor_text";
@@ -97,6 +105,7 @@ const $input     = document.getElementById("prompt-input") as HTMLTextAreaElemen
 const $btnSend   = document.getElementById("btn-send")!;
 const $btnAbort  = document.getElementById("btn-abort")!;
 const $btnNew    = document.getElementById("btn-new")!;
+const $btnHistory = document.getElementById("btn-history")!;
 const $btnAttach = document.getElementById("btn-attach")!;
 const $fileInput = document.getElementById("file-input") as HTMLInputElement;
 const $attachStrip = document.getElementById("attachment-strip")!;
@@ -324,6 +333,12 @@ function handleServerEvent(event: Record<string, unknown>) {
 
     case "extension_error": {
       showToast(`Extension error: ${event.error as string}`, "error");
+      break;
+    }
+
+    case "sessions_list": {
+      const entries = (event.entries as SessionListEntry[]) ?? [];
+      renderSessionsDialog(entries);
       break;
     }
   }
@@ -642,6 +657,79 @@ $btnNew.addEventListener("click", () => {
   // The server will broadcast a state_sync event to every connected client.
   send({ type: "new_session" });
 });
+$btnHistory.addEventListener("click", () => send({ type: "list_sessions" }));
+
+// ── Sessions dialog ───────────────────────────────────────────────────────────
+function renderSessionsDialog(entries: SessionListEntry[]) {
+  const $title = document.getElementById("dialog-title")!;
+  const $msg = document.getElementById("dialog-message")!;
+  const $body = document.getElementById("dialog-body")!;
+  const $actions = document.getElementById("dialog-actions")!;
+  $title.textContent = "Previous chats";
+  $msg.textContent = entries.length === 0
+    ? "No previous sessions in this folder."
+    : `${entries.length} session${entries.length === 1 ? "" : "s"} on disk. Click one to switch.`;
+  $body.innerHTML = "";
+
+  for (const entry of entries) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "dialog-select-option";
+    if (entry.isActive) {
+      btn.style.borderColor = "var(--accent)";
+      btn.style.background = "var(--accent-dim)";
+    }
+    const ts = formatTimestamp(entry.timestamp);
+    const preview = entry.preview || "(no user messages)";
+    btn.innerHTML = "";
+    const head = document.createElement("div");
+    head.style.cssText = "font-size: 11px; color: var(--text-muted); margin-bottom: 4px;";
+    head.textContent = entry.isActive ? `${ts} · current` : ts;
+    const body = document.createElement("div");
+    body.textContent = preview;
+    btn.appendChild(head);
+    btn.appendChild(body);
+    btn.addEventListener("click", () => {
+      if (!entry.isActive) send({ type: "switch_session", file: entry.file });
+      closeDialog();
+    });
+    $body.appendChild(btn);
+  }
+
+  $actions.innerHTML = "";
+  const cancel = document.createElement("button");
+  cancel.type = "button";
+  cancel.className = "btn btn-ghost";
+  cancel.textContent = "Close";
+  cancel.addEventListener("click", closeDialog);
+  $actions.appendChild(cancel);
+
+  $overlay.classList.remove("hidden");
+}
+
+function closeDialog() {
+  $overlay.classList.add("hidden");
+  state.dialog = null;
+}
+
+function formatTimestamp(ts: string): string {
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return ts;
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameDay) {
+    return `Today ${d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+  }
+  return d.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
 
 // ── Attachments ───────────────────────────────────────────────────────────────
 $btnAttach.addEventListener("click", () => $fileInput.click());

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,7 @@ html, body { height: 100%; overflow: hidden; background: var(--bg); color: var(-
   display: flex;
   flex-direction: column;
   height: 100vh;
+  height: 100dvh;
 }
 
 /* ── Header ──────────────────────────────────────────────────────────────── */
@@ -392,3 +393,28 @@ html, body { height: 100%; overflow: hidden; background: var(--bg); color: var(-
 
 /* ── Highlight.js overrides ──────────────────────────────────────────────── */
 .hljs { background: transparent !important; padding: 0 !important; }
+
+/* ── Mobile responsive ───────────────────────────────────────────────────── */
+#app { max-width: 100vw; overflow-x: hidden; }
+.block-text, .msg-bubble { min-width: 0; overflow-wrap: anywhere; }
+.prompt-input { min-width: 0; }
+
+@media (max-width: 640px) {
+  body { font-size: 13px; }
+  #header { padding: 0 10px; height: 44px; }
+  .logo-text { display: none; }
+  .status-text { display: none; }
+  .messages { padding: 12px 0; }
+  .msg { padding: 0 10px; margin-bottom: 14px; }
+  .msg-user .msg-bubble { max-width: 92%; padding: 8px 12px; }
+  .streaming-indicator { padding: 0 10px; }
+  .input-bar { padding: 8px 10px; gap: 6px; }
+  .prompt-input { padding: 9px 10px; font-size: 16px; /* prevent iOS auto-zoom on focus */ }
+  .btn { padding: 6px 10px; font-size: 13px; }
+  .block-text pre { padding: 10px; font-size: 12px; border-radius: 6px; }
+  .block-text h1 { font-size: 1.25em; }
+  .block-text h2 { font-size: 1.1em; }
+  .tool-args-pre, .tool-output-pre { padding-left: 10px; padding-right: 10px; max-height: 240px; }
+  .block-tool .block-header { padding: 6px 10px; }
+  .dialog-box { padding: 16px; min-width: 0; width: 94vw; }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -391,6 +391,49 @@ html, body { height: 100%; overflow: hidden; background: var(--bg); color: var(-
 .toast-error   { background: var(--error-dim); border-color: var(--error); color: var(--error); }
 @keyframes toast-in { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: none; } }
 
+/* ── Attachments ─────────────────────────────────────────────────────────── */
+.attachment-strip {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  max-width: 848px; width: 100%;
+  margin: 0 auto;
+  padding: 8px 24px 0;
+  flex-shrink: 0;
+}
+.attachment-chip {
+  position: relative;
+  width: 56px; height: 56px;
+  border-radius: 6px; overflow: hidden;
+  border: 1px solid var(--border2);
+  background: var(--bg3);
+  flex-shrink: 0;
+}
+.attachment-chip img {
+  width: 100%; height: 100%; object-fit: cover; display: block;
+}
+.attachment-chip .remove {
+  position: absolute; top: 2px; right: 2px;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.7);
+  color: #fff; border: none;
+  font-size: 11px; line-height: 18px; text-align: center;
+  cursor: pointer; padding: 0;
+}
+.attachment-chip .remove:hover { background: rgba(0,0,0,0.9); }
+.btn-attach { font-size: 18px; padding: 4px 10px; line-height: 1; }
+
+.msg-bubble-images {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  margin-bottom: 6px;
+}
+.msg-bubble-images img {
+  max-width: 200px; max-height: 200px;
+  border-radius: 6px; display: block;
+  border: 1px solid var(--border2);
+}
+.msg-user .msg-bubble-images { justify-content: flex-end; }
+.msg-bubble-empty { display: none; }
+
 /* ── Highlight.js overrides ──────────────────────────────────────────────── */
 .hljs { background: transparent !important; padding: 0 !important; }
 
@@ -411,6 +454,10 @@ html, body { height: 100%; overflow: hidden; background: var(--bg); color: var(-
   .input-bar { padding: 8px 10px; gap: 6px; }
   .prompt-input { padding: 9px 10px; font-size: 16px; /* prevent iOS auto-zoom on focus */ }
   .btn { padding: 6px 10px; font-size: 13px; }
+  .btn-attach { padding: 4px 8px; font-size: 16px; }
+  .attachment-strip { padding: 6px 10px 0; }
+  .attachment-chip { width: 48px; height: 48px; }
+  .msg-bubble-images img { max-width: 60vw; max-height: 240px; }
   .block-text pre { padding: 10px; font-size: 12px; border-radius: 6px; }
   .block-text h1 { font-size: 1.25em; }
   .block-text h2 { font-size: 1.1em; }


### PR DESCRIPTION
Three additions tested running on a Mac, accessed from an iPhone via Tailscale.

## 1. Mobile-responsive layout (`38e796b`)

The existing layout was desktop-only; on a phone the input bar sat below the visible viewport (iOS Safari `100vh` includes the URL-bar area) and message text overflowed off-screen.

- `@media (max-width: 640px)` breakpoint tightens header / message / input-bar padding.
- Hides the wordmark and connection-status text on phones to free header room.
- Bumps prompt-input `font-size` to 16px on small screens so iOS Safari doesn't auto-zoom on focus.
- `overflow-wrap: anywhere` on message text and bubbles so long unbroken strings (URLs, tokens) can't push the layout wide.
- `min-width: 0` on the prompt-input so flex doesn't keep it stuck at placeholder-text width.
- `overflow-x: hidden` on `#app` as a safety net.
- `#app` height: `100vh` → `100dvh` (with `100vh` fallback) so the input bar stays inside the visible viewport on mobile Safari when the URL bar is showing.

## 2. Image attachments (`d48d3f6`)

The pi SDK already accepts an `images?: ImageContent[]` array on `PromptOptions`; this wires the existing capability through to the user.

**Server (`server/index.ts`):**
- New `images` field on the `prompt` WebSocket command.
- Validates each entry: shape, mime type (png/jpeg/gif/webp), decoded size (≤10 MB), drops anything that fails.
- Passes through to `session.prompt(text, { images })`.
- Allows image-only prompts (no longer requires text).

**Frontend (`index.html`, `src/main.ts`, `src/style.css`):**
- 📎 button next to the textarea triggers a hidden file input.
- Picked files are FileReader-encoded to base64 and shown as a thumbnail strip above the input bar, each with an × to remove.
- On send, images are packed into the WebSocket payload alongside the text and cleared from the strip.
- User-message bubbles render any attached images inline.
- `state_sync` rehydration extracts image content from past user messages so attachments survive a page reload.

Note: whether the agent can *see* the attached image depends on the active model. Vision-capable models render and reason about it; text-only models receive the payload but ignore the image content.

## 3. Session list + resume (`dcd2e37`)

Previously there was no way to navigate back to a prior chat — clicking ＋ New silently abandoned the current session (the JSONL file on disk was preserved, but the UI didn't expose it). Wires the SDK's existing capability — `AgentSession.switchSession()` and `SessionManager.getSessionDir()` — through to the user.

**Server:**
- `list_sessions` WebSocket command. Reads the SessionManager's session directory, parses each `.jsonl` header, finds the first user message for a preview snippet, sorts newest-first.
- `switch_session` WebSocket command. Validates the requested file is inside the session directory (path-traversal guard), calls `session.switchSession(path)`, then broadcasts `state_sync` so all connected clients re-render.

**Frontend:**
- New "⌛ History" button in the header next to "＋ New".
- Click it → sends `list_sessions` → dialog (reusing the existing `dialog-overlay`) lists prior chats with timestamp + first user-message preview. The active session is highlighted.
- Click an entry → sends `switch_session` → server broadcasts `state_sync` → message list re-hydrates.

## Test plan

- [x] `npm run build` and `npm run build:server` both clean.
- [x] Local server still serves HTTP 200 on `127.0.0.1:8080`.
- [x] Tailscale `serve` proxy delivers HTTPS to a phone, layout fits without horizontal overflow.
- [x] Image picked on phone shows as thumbnail, sends to agent, persists in session JSONL on disk with correct `{ type: "image", data, mimeType }` shape.
- [x] `⌛ History` lists prior sessions in this cwd; clicking one swaps the chat in place.